### PR TITLE
fixtures.yml: Pull dependencies from git

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,12 +1,12 @@
 ---
 fixtures:
-  forge_modules:
-    stdlib: "puppetlabs/stdlib"
-    concat: "puppetlabs/concat"
-    vcsrepo: "puppetlabs/vcsrepo"
-    apt: "puppetlabs/apt"
-    yumrepo: "puppetlabs/yumrepo_core"
-    zypprepo: "puppet/zypprepo"
-    systemd: "camptocamp/systemd"
-    icinga: "icinga/icinga"
-    icinga2: "icinga/icinga2"
+  repositories:
+    stdlib: https://github.com/puppetlabs/puppetlabs-stdlib
+    concat: https://github.com/puppetlabs/puppetlabs-concat
+    vcsrepo: https://github.com/puppetlabs/puppetlabs-vcsrepo
+    apt: https://github.com/puppetlabs/puppetlabs-apt
+    yumrepo_core: https://github.com/puppetlabs/puppetlabs-yumrepo_core
+    zypprepo: https://github.com/voxpupuli/puppet-zypprepo
+    systemd: https://github.com/voxpupuli/puppet-systemd
+    icinga: https://github.com/voxpupuli/puppet-icinga
+    icinga2: https://github.com/voxpupuli/puppet-icinga2


### PR DESCRIPTION
This is the current best practice. In unit tests the .fixtures.yml will be used and we're able to detect breaking changes in dependencies before they are released. In acceptance tests the latest forge releases based on metadata.json will be used.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
