### PR TITLE
Install: Ensure package installed before file resources

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -26,6 +26,9 @@ class icingaweb2::install {
     package { $package_name:
       ensure => installed,
     }
+    File {
+      require => Package[$package_name],
+    }
   }
 
   if $extra_packages {
@@ -71,7 +74,7 @@ class icingaweb2::install {
     mode   => '0755',
   }
 
-  exec { 'link old db schema directory for compatibility':
+  -> exec { 'link old db schema directory for compatibility':
     path    => $facts['path'],
     command => "ln -s ${data_dir}/schema ${comp_dir}/schema",
     unless  => "stat ${comp_dir}/schema",


### PR DESCRIPTION
This sets a require on the package for all file resources in the install class, as sometimes Puppet tries to create these before it's installed. It also chains the DB schema copy exec to the necessary directory.

Fixes #421 