### PR TITLE
Add module perfdatagraphs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -23,6 +23,7 @@
 * [`icingaweb2::module::idoreports`](#icingaweb2--module--idoreports): Installs, configures and enables the idoreports module. The module is deprecated.
 * [`icingaweb2::module::monitoring`](#icingaweb2--module--monitoring): Manages the monitoring module. This module is deprecated.
 * [`icingaweb2::module::pdfexport`](#icingaweb2--module--pdfexport): Installs, configures and enables the pdfexport module.
+* [`icingaweb2::module::perfdatagraphs`](#icingaweb2--module--perfdatagraphs): Installs and enables the perfdatagraphs module.
 * [`icingaweb2::module::puppetdb`](#icingaweb2--module--puppetdb): Installs and configures the puppetdb module.
 * [`icingaweb2::module::reporting`](#icingaweb2--module--reporting): Installs the reporting module
 * [`icingaweb2::module::translation`](#icingaweb2--module--translation): Installs and configures the translation module.
@@ -2448,6 +2449,90 @@ Default value: `undef`
 Data type: `Optional[Stdlib::Port]`
 
 Port to connect the remote running Chrome/Chromium.
+
+Default value: `undef`
+
+### <a name="icingaweb2--module--perfdatagraphs"></a>`icingaweb2::module::perfdatagraphs`
+
+Installs and enables the perfdatagraphs module.
+
+* **Note** If you want to use `git` as `install_method`, the CLI `git` command has to be installed.
+
+#### Parameters
+
+The following parameters are available in the `icingaweb2::module::perfdatagraphs` class:
+
+* [`ensure`](#-icingaweb2--module--perfdatagraphs--ensure)
+* [`module_dir`](#-icingaweb2--module--perfdatagraphs--module_dir)
+* [`git_repository`](#-icingaweb2--module--perfdatagraphs--git_repository)
+* [`git_revision`](#-icingaweb2--module--perfdatagraphs--git_revision)
+* [`install_method`](#-icingaweb2--module--perfdatagraphs--install_method)
+* [`package_name`](#-icingaweb2--module--perfdatagraphs--package_name)
+* [`default_backend`](#-icingaweb2--module--perfdatagraphs--default_backend)
+* [`default_timerange`](#-icingaweb2--module--perfdatagraphs--default_timerange)
+* [`cache_lifetime`](#-icingaweb2--module--perfdatagraphs--cache_lifetime)
+
+##### <a name="-icingaweb2--module--perfdatagraphs--ensure"></a>`ensure`
+
+Data type: `Enum['absent', 'present']`
+
+Enable or disable module.
+
+##### <a name="-icingaweb2--module--perfdatagraphs--module_dir"></a>`module_dir`
+
+Data type: `Stdlib::Absolutepath`
+
+Target directory of the module.
+
+Default value: `"${icingaweb2::globals::default_module_path}/perfdatagraphs"`
+
+##### <a name="-icingaweb2--module--perfdatagraphs--git_repository"></a>`git_repository`
+
+Data type: `Stdlib::HTTPUrl`
+
+Set a git repository URL.
+
+##### <a name="-icingaweb2--module--perfdatagraphs--git_revision"></a>`git_revision`
+
+Data type: `Optional[String[1]]`
+
+Set either a branch or a tag name, eg. `main` or `v0.1.1`.
+
+Default value: `undef`
+
+##### <a name="-icingaweb2--module--perfdatagraphs--install_method"></a>`install_method`
+
+Data type: `Enum['git', 'none', 'package']`
+
+Install methods are `git`, `package` and `none` is supported as installation method.
+
+##### <a name="-icingaweb2--module--perfdatagraphs--package_name"></a>`package_name`
+
+Data type: `Optional[String[1]]`
+
+Package name of the module. This setting is only valid in combination with the installation method `package`.
+
+Default value: `undef`
+
+##### <a name="-icingaweb2--module--perfdatagraphs--default_backend"></a>`default_backend`
+
+Data type: `Enum['Graphite']`
+
+Backend type.
+
+##### <a name="-icingaweb2--module--perfdatagraphs--default_timerange"></a>`default_timerange`
+
+Data type: `String[1]`
+
+Default timerange to show. Has to be in format defined in ISO 8601, e.g. PT12H.
+
+Default value: `'PT12H'`
+
+##### <a name="-icingaweb2--module--perfdatagraphs--cache_lifetime"></a>`cache_lifetime`
+
+Data type: `Optional[Integer[1]]`
+
+Cache lifetime in seconds.
 
 Default value: `undef`
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -155,3 +155,7 @@ icingaweb2::module::puppetdb::git_repository: https://github.com/Icinga/icingawe
 icingaweb2::module::puppetdb::install_method: git
 icingaweb2::module::puppetdb::ssl: none
 icingaweb2::module::puppetdb::certificates: {}
+
+icingaweb2::module::perfdatagraphs::ensure: present
+icingaweb2::module::perfdatagraphs::git_repository: https://github.com/NETWAYS/icingaweb2-module-perfdatagraphs.git
+icingaweb2::module::perfdatagraphs::install_method: git

--- a/manifests/module/perfdatagraphs.pp
+++ b/manifests/module/perfdatagraphs.pp
@@ -1,0 +1,71 @@
+# @summary
+#   Installs and enables the perfdatagraphs module.
+#
+# @note If you want to use `git` as `install_method`, the CLI `git` command has to be installed.
+#
+# @param ensure
+#   Enable or disable module.
+#
+# @param module_dir
+#   Target directory of the module.
+#
+# @param git_repository
+#   Set a git repository URL.
+#
+# @param git_revision
+#   Set either a branch or a tag name, eg. `main` or `v0.1.1`.
+#
+# @param install_method
+#   Install methods are `git`, `package` and `none` is supported as installation method.
+#
+# @param package_name
+#   Package name of the module. This setting is only valid in combination with the installation method `package`.
+#
+# @param default_backend
+#   Backend type.
+#
+# @param default_timerange
+#   Default timerange to show. Has to be in format defined in ISO 8601, e.g. PT12H.
+#
+# @param cache_lifetime
+#   Cache lifetime in seconds.
+#
+class icingaweb2::module::perfdatagraphs (
+  Enum['absent', 'present']      $ensure,
+  Stdlib::HTTPUrl                $git_repository,
+  Enum['git', 'none', 'package'] $install_method,
+  Enum['Graphite']               $default_backend,
+  String[1]                      $default_timerange = 'PT12H',
+  Optional[Integer[1]]           $cache_lifetime    = undef,
+  Optional[String[1]]            $package_name      = undef,
+  Stdlib::Absolutepath           $module_dir        = "${icingaweb2::globals::default_module_path}/perfdatagraphs",
+  Optional[String[1]]            $git_revision      = undef,
+) {
+  require icingaweb2
+
+  $conf_dir        = $icingaweb2::globals::conf_dir
+  $module_conf_dir = "${conf_dir}/modules/perfdatagraphs"
+  $config_settings = {
+    default_backend   => $default_backend,
+    default_timerange => $default_timerange,
+    cache_lifetime    => $cache_lifetime,
+  }
+
+  $settings = {
+    'icingaweb2-module-perfdatagraphs' => {
+      'section_name' => 'perfdatagraphs',
+      'target'       => "${module_conf_dir}/config.ini",
+      'settings'     => delete_undef_values($config_settings),
+    },
+  }
+
+  icingaweb2::module { 'perfdatagraphs':
+    ensure         => $ensure,
+    git_repository => $git_repository,
+    git_revision   => $git_revision,
+    install_method => $install_method,
+    module_dir     => $module_dir,
+    package_name   => $package_name,
+    settings       => $settings,
+  }
+}

--- a/spec/classes/modules/perfdatagraphs_spec.rb
+++ b/spec/classes/modules/perfdatagraphs_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe('icingaweb2::module::perfdatagraphs', type: :class) do
+  let(:pre_condition) do
+    [
+      "class { 'icingaweb2': db_type => 'mysql', db_password => 'secret' }",
+    ]
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let :facts do
+        facts
+      end
+
+      context "#{os} with git_revision 'v0.1.1'" do
+        let(:params) { { git_revision: 'v0.1.1', default_backend: 'Graphite' } }
+
+        it {
+          is_expected.to contain_icingaweb2__module('perfdatagraphs')
+            .with_install_method('git')
+            .with_git_revision('v0.1.1')
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__inisection('icingaweb2-module-perfdatagraphs')
+            .with_section_name('perfdatagraphs')
+            .with_target('/etc/icingaweb2/modules/perfdatagraphs/config.ini')
+            .with_settings('default_backend' => 'Graphite', 'default_timerange' => 'PT12H')
+        }
+      end
+
+      context "#{os} with all parameters set" do
+        let(:params) do
+          {
+            git_revision: 'v0.1.1',
+            default_backend: 'Graphite',
+            default_timerange: 'PT6H30M',
+            cache_lifetime: 3,
+          }
+        end
+
+        it {
+          is_expected.to contain_icingaweb2__module('perfdatagraphs')
+            .with_install_method('git')
+            .with_git_revision('v0.1.1')
+        }
+
+        it {
+          is_expected.to contain_icingaweb2__inisection('icingaweb2-module-perfdatagraphs')
+            .with_section_name('perfdatagraphs')
+            .with_target('/etc/icingaweb2/modules/perfdatagraphs/config.ini')
+            .with_settings('default_backend' => 'Graphite', 'default_timerange' => 'PT6H30M', 'cache_lifetime' => 3)
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Support module https://github.com/NETWAYS/icingaweb2-module-perfdatagraphs to visualize performance graphs. Backend module for other specialized modules for graphite and influxdb v1/v2 support. 